### PR TITLE
Add lowercase matching in GCRatioStrategy

### DIFF
--- a/goldilocks/strategies.py
+++ b/goldilocks/strategies.py
@@ -100,7 +100,7 @@ class GCRatioStrategy(BaseStrategy):
         self.RATIO_OF = None
 
     def census(self, sequence, track, **kwargs):
-        return float(len(self.modules["re"].findall("[GC]", sequence)))/len(sequence)
+        return float(len(self.modules["re"].findall("[GCgc]", sequence)))/len(sequence)
 
 class ReferenceConsensusStrategy(BaseStrategy): # pragma: no cover
 


### PR DESCRIPTION
The other strategies already are case-insensitive matching, GCRatioStrategy bails out on sequences that are entirely lowercase and silently fails on sequences that are partially lowercase. Adding `gc` to the match charset fixes this.